### PR TITLE
feat: add pointer supply info (#1)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ behaviours to avoid.
 
 ## Reentrant Calls
 
-Some tokens allow reentract calls on transfer (e.g. `ERC777` tokens).
+Some tokens allow reentrant calls on transfer (e.g. `ERC777` tokens).
 
 This has been exploited in the wild on multiple occasions (e.g. [imBTC uniswap pool
 drained](https://defirate.com/imbtc-uniswap-hack/), [lendf.me
@@ -54,13 +54,13 @@ Some tokens (e.g. `BNB`) may return a `bool` for some methods, but fail to do so
 resulted in stuck `BNB` tokens in Uniswap v1
 ([details](https://mobile.twitter.com/UniswapProtocol/status/1072286773554876416)).
 
-Some particulary pathological tokens (e.g. Tether Gold) declare a bool return, but then return
+Some particularly pathological tokens (e.g. Tether Gold) declare a bool return, but then return
 `false` even when the transfer was successful
 ([code](https://etherscan.io/address/0x4922a015c4407f87432b179bb209e125432e4a2a#code)).
 
 A good safe transfer abstraction
 ([example](https://github.com/Uniswap/uniswap-v2-core/blob/4dd59067c76dea4a0e8e4bfdda41877a6b16dedc/contracts/UniswapV2Pair.sol#L44))
-can help somewhat, but note that the existance of Tether Gold makes it impossible to correctly handle
+can help somewhat, but note that the existence of Tether Gold makes it impossible to correctly handle
 return values for all tokens.
 
 Two example tokens are provided:
@@ -91,7 +91,7 @@ modifications to underlying balances can mean that the contract is operating wit
 information.
 
 In the case of Ampleforth, some Balancer and Uniswap pools are special cased to ensure that the
-pool's cached balances are atomically updated as part of the rebase prodecure
+pool's cached balances are atomically updated as part of the rebase procedure
 ([details](https://www.ampltalk.org/app/forum/technology-development-17/topic/supported-dex-pools-61/)).
 
 *example*: TODO: implement a rebasing token
@@ -139,7 +139,7 @@ extortion attempt against users of the blocked contract.
 
 Some tokens can be paused by an admin (e.g. `BNB`, `ZIL`).
 
-Similary to the blocklist issue above, an admin controlled pause feature opens users
+Similarly to the blocklist issue above, an admin controlled pause feature opens users
 of the token to risk from a malicious or compromised token owner.
 
 *example*: [Pausable.sol](./src/Pausable.sol)
@@ -166,7 +166,7 @@ Integrators may need to add special cases to handle this logic if working with s
 
 ## Revert on Zero Value Transfers
 
-Some tokens (e.g. `LEND`) revert when transfering a zero value amount.
+Some tokens (e.g. `LEND`) revert when transferring a zero value amount.
 
 *example*: [RevertZero.sol](./src/RevertZero.sol)
 
@@ -174,7 +174,7 @@ Some tokens (e.g. `LEND`) revert when transfering a zero value amount.
 
 Some proxied tokens have multiple addresses. 
 As an example consider the following snippet. `rescueFunds` is intended to allow the contract owner
-to return non pool tokens that were accidentaly sent to the contract. However, it assumes a single
+to return non pool tokens that were accidentally sent to the contract. However, it assumes a single
 address per token and so would allow the owner to steal all funds in the pool.
 
 ```solidity
@@ -238,7 +238,7 @@ This may cause issues when trying to consume metadata from these tokens.
 
 Some tokens (e.g. openzeppelin) revert when attempting to transfer to `address(0)`.
 
-This may break systems that expect to be able to burn tokens by transfering them to `address(0)`.
+This may break systems that expect to be able to burn tokens by transferring them to `address(0)`.
 
 *example*: [RevertToZero.sol](./src/RevertToZero.sol)
 
@@ -247,7 +247,7 @@ This may break systems that expect to be able to burn tokens by transfering them
 Some tokens do not revert on failure, but instead return `false` (e.g.
 [ZRX](https://etherscan.io/address/0xe41d2489571d322189246dafa5ebde1f4699f498#code)).
 
-While this is technicaly compliant with the ERC20 standard, it goes against common solidity coding
+While this is technically compliant with the ERC20 standard, it goes against common solidity coding
 practices and may be overlooked by developers who forget to wrap their calls to `transfer` in a
 `require`.
 
@@ -270,3 +270,12 @@ allowing attackers to extract private keys from users who choose to interact wit
 vulnerable frontends.
 
 This has been used to exploit etherdelta users in the wild ([reference](https://hackernoon.com/how-one-hacker-stole-thousands-of-dollars-worth-of-cryptocurrency-with-a-classic-code-injection-a3aba5d2bff0)).
+
+## ERC20 Pointer Supply
+
+An ERC20-Token where total supply is calculated from minted and burned tokens
+This is different from a classic ERC20 implementation as the supply is calculated from the burned and minted tokens instead of stored in its own variable.
+
+Unowned tokens belong to this contract and their supply can be calculated implicitly. This means we need to manually track owned tokens, but it makes operations on unowned tokens much more efficient.
+
+[See reference implementation in LiquidGasToken](https://github.com/matnad/liquid-gas-token/blob/master/contracts/ERC20PointerSupply.sol#L8-L181)


### PR DESCRIPTION
This adds info about an implementation referred to as 'Pointer Supply' that is (was?) used in Liquid Gas Token.

[see https://github.com/matnad/liquid-gas-token/blob/master/contracts/ERC20PointerSupply.sol#L8-L181](https://github.com/matnad/liquid-gas-token/blob/master/contracts/ERC20PointerSupply.sol#L8-L181)

Not sure if you wanted a test case to include as this is the only implementation that I know of using this, and its based offf of a gas return mechanism that is no longer applicable post-Berlin/London 