### PR TITLE
typo : renamed to RevertToZero token

### DIFF
--- a/src/RevertToZero.sol
+++ b/src/RevertToZero.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.6.12;
 
 import {ERC20} from "./ERC20.sol";
 
-contract ReentrantToken is ERC20 {
+contract RevertToZeroToken is ERC20 {
     // --- Init ---
     constructor(uint _totalSupply) ERC20(_totalSupply) public {}
 


### PR DESCRIPTION
found this typo while building [erc20 testing template](https://github.com/leekt/macbeth).

RevertToZero.sol contains contract named "ReentrantToken"
Which does not represents the contract properly
Also, there is a file "Reentrant.sol" which contains "ReentrantToken"
Will be much more approporiate to renamed the token to "RevertToZero" token