### PR TITLE
fix: rename ERC20 to Uint96ERC20

### DIFF
--- a/src/Uint96.sol
+++ b/src/Uint96.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.6.12;
 
-contract ERC20 {
+contract Uint96ERC20 {
     // --- ERC20 Data ---
     string  public constant name = "Token";
     string  public constant symbol = "TKN";


### PR DESCRIPTION
In order to avoid the "Identifier already declared." error, I suggest the renaming of it.