### PR TITLE
Fix daipermit and upgradeable

### DIFF
--- a/src/Upgradable.sol
+++ b/src/Upgradable.sol
@@ -12,8 +12,14 @@ contract Proxy {
     // --- init ---
 
     constructor(uint totalSupply) public {
-        give(msg.sender);
+
+        // Manual give()
+        bytes32 slot = ADMIN_KEY;
+        address usr = msg.sender;
+        assembly { sstore(slot, usr) }
+
         upgrade(address(new ERC20(totalSupply)));
+
     }
 
     // --- auth ---


### PR DESCRIPTION
Both DaiPermit and Upgradeable are unable to be deployed and used for testing.

DaiPermit requires a  `DOMAIN_SEPARATOR` const and a `nonces` mapping for the `permit()` fn

Upgradeable always fails on deploy due to not-yet-enabled access control in the `auth` modifier. This fix makes the constructor manually perform the `give()` fn, avoiding the modifier.