### PR TITLE
Added example for approval with zero value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,13 +162,15 @@ Some tokens (e.g. OpenZeppelin) will revert if trying to approve the zero addres
 
 Integrators may need to add special cases to handle this logic if working with such a token.
 
-*example*: [ApprovalToZero.sol](./src/ApprovalToZero.sol)
+*example*: [ApprovalToZeroAddress.sol](./src/ApprovalToZeroAddress.sol)
 
 ## Revert on Zero Value Approvals
 
 Some tokens (e.g. `BNB`) revert when approving a zero value amount (i.e. a call to `approve(address, 0)`).
 
 Integrators may need to add special cases to handle this logic if working with such a token.
+
+*example*: [ApprovalWithZeroValue.sol](./src/ApprovalWithZeroValue.sol)
 
 ## Revert on Zero Value Transfers
 

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,12 @@ Integrators may need to add special cases to handle this logic if working with s
 
 *example*: [ApprovalToZero.sol](./src/ApprovalToZero.sol)
 
+## Revert on Zero Value Approvals
+
+Some tokens (e.g. `BNB`) revert when approving a zero value amount (i.e. a call to `approve(address, 0)`).
+
+Integrators may need to add special cases to handle this logic if working with such a token.
+
 ## Revert on Zero Value Transfers
 
 Some tokens (e.g. `LEND`) revert when transferring a zero value amount.

--- a/src/ApprovalToZeroAddress.sol
+++ b/src/ApprovalToZeroAddress.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.6.12;
 
 import {ERC20} from "./ERC20.sol";
 
-contract ApprovalToZeroToken is ERC20 {
+contract ApprovalToZeroAddressToken is ERC20 {
     // --- Init ---
     constructor(uint _totalSupply) ERC20(_totalSupply) public {}
 

--- a/src/ApprovalWithZeroValue.sol
+++ b/src/ApprovalWithZeroValue.sol
@@ -1,0 +1,17 @@
+// Copyright (C) 2020 d-xo
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity >=0.6.12;
+
+import {ERC20} from "./ERC20.sol";
+
+contract ApprovalWithZeroValueToken is ERC20 {
+    // --- Init ---
+    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+
+    // --- Token ---
+    function approve(address usr, uint wad) override public returns (bool) {
+        require(wad > 0, "no approval with zero value");
+        return super.approve(usr, wad);
+    }
+}


### PR DESCRIPTION
Hi, I added an example for approval with zero value. One such token that comes to mind is [BNB line 92](https://etherscan.io/token/0xB8c77482e45F1F44dE1745F52C74426C631bDD52#code) as it reverts on 0 approval.

I think BNB is popular enough and because using `safeApprove()` is considered industry best practice, integrators should be aware that they cannot support BNB.

I differentiated between approving to zero address and approving with zero value. I tried to keep to the existing convention. LMK if more changes are required!