### PR TITLE
Add FLOKI to tokens who revert on 0 value transfers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ Integrators may need to add special cases to handle this logic if working with s
 
 ## Revert on Zero Value Transfers
 
-Some tokens (e.g. `LEND`) revert when transferring a zero value amount.
+Some tokens (e.g. `FLOKI`, `LEND`) revert when transferring a zero value amount.
 
 *example*: [RevertZero.sol](./src/RevertZero.sol)
 


### PR DESCRIPTION
`FLOKI` is a famous token (currently \#48 on Coinmarketcap) that reverts on 0 value transfers:

```sol
    function _transfer(
        address from,
        address to,
        uint256 amount
    ) private {
        // ...
        require(amount > 0, "FLOKI:_transfer:ZERO_AMOUNT: Transfer amount must be greater than zero.");
        // ...
    }
```

https://github.com/Floki-Inu/token/blob/master/contracts/Floki.sol#L442